### PR TITLE
Support for multipart 7z archives

### DIFF
--- a/modules/archive/functions/unarchive
+++ b/modules/archive/functions/unarchive
@@ -37,6 +37,6 @@ case "${archive_name}" in
   (*.rar) unrar &> /dev/null \
     && unrar x -ad "${archive_name}" \
     || rar x -ad "${archive_name}" ;;
-  (*.7z) 7za x "${archive_name}" ;;
+  (*.7z|*.7z.001) 7za x "${archive_name}" ;;
   (*) print "${0}: unknown archive type: ${archive_name}" ;;
 esac


### PR DESCRIPTION
Add support for unarchiving of multipart 7z archives.
Example: 
`unarchive multipart.7z.001` 
